### PR TITLE
Add dataset access URL and required auth env vars to subsetting/data services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,22 +9,43 @@ services:
     - external
     - monitoring-ext
     environment:
-      # if ascertaining DB via LDAP
-      LDAP_SERVER:
-      ORACLE_BASE_DN:
-      APP_DB_TNS_NAME:
-      # if using DB name directly
-      APP_DB_NAME:
-      APP_DB_HOST:
-      # connection credentials (needed regardless of method)
-      APP_DB_USER:
-      APP_DB_PASS:
-      APP_DB_SCHEMA: ${APP_DB_SCHEMA:-apidb.}
       # port providing the service
       SERVER_PORT: ${SUBSETTING_SERVER_PORT:-8080}
+
+      # URLs of required services
+      DATASET_ACCESS_SERVICE_URL: ${DATASET_ACCESS_SERVICE_URL}
+
+      # LDAP values to look up DBs
+      LDAP_SERVER: ${LDAP_SERVER}
+      ORACLE_BASE_DN: ${ORACLE_BASE_DN}
+
+      # Application Database
+      APP_DB_TNS_NAME: ${APP_DB_TNS_NAME}
+      APP_DB_USER: ${APP_DB_USER}
+      APP_DB_PASS: ${APP_DB_PASS}
+      APP_DB_SCHEMA: ${APP_DB_SCHEMA:-eda.}
+
+      # Account Database
+      ACCT_DB_TNS_NAME: ${ACCT_DB_TNS_NAME}
+      ACCT_DB_USER: ${ACCT_DB_USER}
+      ACCT_DB_PASS: ${ACCT_DB_PASS}
+
+      # User Database
+      USER_DB_TNS_NAME: ${USER_DB_TNS_NAME}
+      USER_DB_USER: ${USER_DB_USER}
+      USER_DB_PASS: ${USER_DB_PASS}
+
+      # Auth Secret (needed along with user/acct DBs for auth)
+      AUTH_SECRET_KEY: ${AUTH_SECRET_KEY}
+
     labels:
     - "prometheus.scrape_enabled=true"
     - "com.centurylinklabs.watchtower.enable=${SUBSETTING_WATCHTOWER:-false}"
+    - "traefik.http.services.${TRAEFIK_SUBSETTING_ROUTER:-edasubsetting-dev}.loadbalancer.server.port=${SUBSETTING_SERVER_PORT:-8080}"
+    - "traefik.http.routers.${TRAEFIK_SUBSETTING_ROUTER:-edasubsetting-dev}.rule=Host(`${TRAEFIK_DATA_HOST:-edadata-dev.local.apidb.org}`) && PathPrefix(`/studies/`)"
+    - "traefik.http.routers.${TRAEFIK_SUBSETTING_ROUTER:-edasubsetting-dev}.tls=true"
+    - "traefik.http.routers.${TRAEFIK_SUBSETTING_ROUTER:-edasubsetting-dev}.entrypoints=${TRAEFIK_ENTRYPOINTS:-local}"
+    - "traefik.docker.network=traefik"
 
   merging:
     image: veupathdb/eda-merging:${MERGING_TAG:-latest}
@@ -32,8 +53,12 @@ services:
     - internal
     - monitoring-ext
     environment:
-      SUBSETTING_SERVICE_URL: ${SUBSETTING_SERVICE_URL:-http://subsetting}:${SUBSETTING_SERVER_PORT:-8080}
+      # port providing the service
       SERVER_PORT: ${MERGING_SERVER_PORT:-8080}
+
+      # URLs of required services
+      SUBSETTING_SERVICE_URL: ${SUBSETTING_SERVICE_URL:-http://subsetting}:${SUBSETTING_SERVER_PORT:-8080}
+
     labels:
     - "prometheus.scrape_enabled=true"
     - "com.centurylinklabs.watchtower.enable=${MERGING_WATCHTOWER:-false}"
@@ -45,10 +70,32 @@ services:
     - traefik
     - monitoring-ext
     environment:
+      # port providing the service
+      SERVER_PORT: ${DATA_SERVER_PORT:-8080}
+
+      # URLs of required services
       SUBSETTING_SERVICE_URL: ${SUBSETTING_SERVICE_URL:-http://subsetting}:${SUBSETTING_SERVER_PORT:-8080}
       MERGING_SERVICE_URL: ${MERGING_SERVICE_URL:-http://merging}:${MERGING_SERVER_PORT:-8080}
       RSERVE_URL: ${RSERVE_URL:-http://rserve:6311}
-      SERVER_PORT: ${DATA_SERVER_PORT:-8080}
+      DATASET_ACCESS_SERVICE_URL: ${DATASET_ACCESS_SERVICE_URL}
+
+      # LDAP values to look up DBs
+      LDAP_SERVER: ${LDAP_SERVER}
+      ORACLE_BASE_DN: ${ORACLE_BASE_DN}
+
+      # Account Database
+      ACCT_DB_TNS_NAME: ${ACCT_DB_TNS_NAME}
+      ACCT_DB_USER: ${ACCT_DB_USER}
+      ACCT_DB_PASS: ${ACCT_DB_PASS}
+
+      # User Database
+      USER_DB_TNS_NAME: ${USER_DB_TNS_NAME}
+      USER_DB_USER: ${USER_DB_USER}
+      USER_DB_PASS: ${USER_DB_PASS}
+
+      # Auth Secret (needed along with user/acct DBs for auth)
+      AUTH_SECRET_KEY: ${AUTH_SECRET_KEY}
+
     labels:
     - "prometheus.scrape_enabled=true"
     - "com.centurylinklabs.watchtower.enable=${DATA_WATCHTOWER:-false}"
@@ -73,8 +120,10 @@ services:
     - traefik
     - monitoring-ext
     environment:
-      AUTH_SECRET_KEY: ${AUTH_SECRET_KEY}
+      # port providing the service
       SERVER_PORT: ${USER_SERVER_PORT:-8080}
+
+      # LDAP values to look up DBs
       LDAP_SERVER: ${LDAP_SERVER}
       ORACLE_BASE_DN: ${ORACLE_BASE_DN}
 
@@ -87,6 +136,9 @@ services:
       USER_DB_TNS_NAME: ${USER_DB_TNS_NAME}
       USER_DB_USER: ${USER_DB_USER}
       USER_DB_PASS: ${USER_DB_PASS}
+
+      # Auth Secret (needed along with user/acct DBs for auth)
+      AUTH_SECRET_KEY: ${AUTH_SECRET_KEY}
 
     labels:
     - "prometheus.scrape_enabled=true"


### PR DESCRIPTION
Bob, the diff here is bigger than it looks (sorry).  The main change that concerns you is the addition of a newly required env var: DATASET_ACCESS_SERVICE_URL, which needs to point to the deployed dataset access service on the same server (not part of this compose stack).