### PR TITLE
Demonstrate a simple visualization result cache

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/AbstractPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/AbstractPlugin.java
@@ -86,7 +86,7 @@ public abstract class AbstractPlugin<T extends VisualizationRequestBase, S, R> i
   private Timer _timer;
   private boolean _requestProcessed = false;
   private String _studyId;
-  private List<APIFilter> _subset;
+  private List<APIFilter> _subsetFilters;
   private List<DerivedVariableSpec> _derivedVariableSpecs;
   private EdaSubsettingClient _subsettingClient;
   private EdaMergingClient _mergingClient;
@@ -107,7 +107,7 @@ public abstract class AbstractPlugin<T extends VisualizationRequestBase, S, R> i
         getSpecObject(request, "getComputeConfig", getComputeConfigClass())));
 
     // check for subset and derived entity properties of request
-    _subset = Optional.ofNullable(request.getFilters()).orElse(Collections.emptyList());
+    _subsetFilters = Optional.ofNullable(request.getFilters()).orElse(Collections.emptyList());
     _derivedVariableSpecs = Optional.ofNullable(request.getDerivedVariables()).orElse(Collections.emptyList());
 
     // build clients for required services
@@ -161,7 +161,7 @@ public abstract class AbstractPlugin<T extends VisualizationRequestBase, S, R> i
     // create stream generator
     Optional<TwoTuple<String,Object>> typedTuple = _computeInfo.map(info -> new TwoTuple<>(info.getFirst(), info.getSecond()));
     Function<StreamSpec, ResponseFuture> streamGenerator = spec -> _mergingClient
-        .getTabularDataStream(_referenceMetadata, _subset, typedTuple, spec);
+        .getTabularDataStream(_referenceMetadata, _subsetFilters, typedTuple, spec);
 
     // create stream processor
     // TODO: might make disallowing empty results optional in the future; this is the original implementation
@@ -178,6 +178,10 @@ public abstract class AbstractPlugin<T extends VisualizationRequestBase, S, R> i
 
   protected S getPluginSpec() {
     return _pluginSpec;
+  }
+
+  protected List<APIFilter> getSubsetFilters() {
+    return _subsetFilters;
   }
 
   protected ReferenceMetadata getReferenceMetadata() {
@@ -261,7 +265,7 @@ public abstract class AbstractPlugin<T extends VisualizationRequestBase, S, R> i
   private ComputeRequestBody createComputeRequestBody() {
     return new ComputeRequestBody(
         _studyId,
-        _subset,
+        _subsetFilters,
         _derivedVariableSpecs,
         _computeInfo.map(TwoTuple::getSecond).orElseThrow(NO_COMPUTE_EXCEPTION));
   }

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/sample/RecordCountPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/sample/RecordCountPlugin.java
@@ -1,22 +1,40 @@
 package org.veupathdb.service.eda.ds.plugin.sample;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Scanner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.gusdb.fgputil.EncryptionUtil;
 import org.gusdb.fgputil.ListBuilder;
+import org.gusdb.fgputil.Timer;
 import org.gusdb.fgputil.Wrapper;
+import org.gusdb.fgputil.cache.ManagedMap;
+import org.gusdb.fgputil.cache.ValueProductionException;
+import org.gusdb.fgputil.json.JsonUtil;
 import org.gusdb.fgputil.validation.ValidationException;
-import org.json.JSONObject;
 import org.veupathdb.service.eda.common.client.spec.StreamSpec;
 import org.veupathdb.service.eda.common.model.VariableSource;
 import org.veupathdb.service.eda.ds.plugin.AbstractEmptyComputePlugin;
 import org.veupathdb.service.eda.generated.model.RecordCountPostRequest;
+import org.veupathdb.service.eda.generated.model.RecordCountPostResponse;
+import org.veupathdb.service.eda.generated.model.RecordCountPostResponseImpl;
 import org.veupathdb.service.eda.generated.model.RecordCountSpec;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+
 public class RecordCountPlugin extends AbstractEmptyComputePlugin<RecordCountPostRequest, RecordCountSpec> {
+
+  private static final Logger LOG = LogManager.getLogger(RecordCountPlugin.class);
+
+  private static final ManagedMap<String,RecordCountPostResponse> RESULT_CACHE =
+      new ManagedMap<>(5000, 2000);
+
+  private String _cacheKey;
+  private RecordCountPostResponse _cachedResponse;
 
   @Override
   public String getDisplayName() {
@@ -41,8 +59,13 @@ public class RecordCountPlugin extends AbstractEmptyComputePlugin<RecordCountPos
 
   @Override
   protected List<StreamSpec> getRequestedStreams(RecordCountSpec pluginSpec) {
+    String entityId = pluginSpec.getEntityId();
+    _cacheKey = EncryptionUtil.md5(JsonUtil.serializeObject(getSubsetFilters()) + "|" + entityId);
+    _cachedResponse = RESULT_CACHE.get(_cacheKey);
+    LOG.info("Did I find a cached response? " + (_cachedResponse != null));
+
     // only need one stream for the requested entity and no vars (IDs included automatically)
-    return ListBuilder.asList(
+    return _cachedResponse != null ? Collections.emptyList() : ListBuilder.asList(
       new StreamSpec(pluginSpec.getEntityId(), pluginSpec.getEntityId())
         // add first var in entity to work around no-vars bug in subsetting service
         .addVar(getReferenceMetadata().getEntity(pluginSpec.getEntityId()).orElseThrow().stream()
@@ -52,12 +75,27 @@ public class RecordCountPlugin extends AbstractEmptyComputePlugin<RecordCountPos
 
   @Override
   protected void writeResults(OutputStream out, Map<String, InputStream> dataStreams) throws IOException {
-    Wrapper<Integer> rowCount = new Wrapper<>(0);
-    new Scanner(dataStreams.get(getPluginSpec().getEntityId()))
-        .useDelimiter("\n")
-        .forEachRemaining(str -> rowCount.set(rowCount.get() + 1));
-    int recordCount = rowCount.get() - 1; // subtract 1 for header row
-    out.write(new JSONObject().put("recordCount", recordCount).toString().getBytes());
+    if (_cachedResponse == null) {
+      LOG.info("Result not in cache; calculating");
+      try {
+        _cachedResponse = RESULT_CACHE.getValue(_cacheKey, key -> {
+          Timer t = new Timer();
+          Wrapper<Integer> rowCount = new Wrapper<>(0);
+          new Scanner(dataStreams.get(getPluginSpec().getEntityId()))
+              .useDelimiter("\n")
+              .forEachRemaining(str -> rowCount.set(rowCount.get() + 1));
+          int recordCount = rowCount.get() - 1; // subtract 1 for header row
+          RecordCountPostResponse value = new RecordCountPostResponseImpl();
+          value.setRecordCount(recordCount);
+          LOG.info("Calculated result to add to cache in " + t.getElapsedString());
+          return value;
+        });
+      }
+      catch (ValueProductionException e) {
+        throw new RuntimeException("Could not generate entity count", e);
+      }
+    }
+    out.write(JsonUtil.serializeObject(_cachedResponse).getBytes());
     out.flush();
   }
 }


### PR DESCRIPTION
This PR demonstrates how we can cache results of the future stats endpoint for use by other plugins or by the web client.