### PR TITLE
Fix map marker stuck bug

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/pass/MapPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/pass/MapPlugin.java
@@ -1,5 +1,7 @@
 package org.veupathdb.service.eda.ds.plugin.pass;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.gusdb.fgputil.DelimitedDataParser;
 import org.gusdb.fgputil.ListBuilder;
 import org.gusdb.fgputil.geo.GeographyUtil.GeographicPoint;
@@ -23,6 +25,7 @@ import static org.gusdb.fgputil.FormatUtil.TAB;
 import static org.veupathdb.service.eda.ds.metadata.AppsMetadata.CLINEPI_PROJECT;
 
 public class MapPlugin extends AbstractEmptyComputePlugin<MapPostRequest, MapSpec> {
+  private static final Logger LOG = LogManager.getLogger(MapPlugin.class);
 
   @Override
   public String getDisplayName() {
@@ -101,7 +104,7 @@ public class MapPlugin extends AbstractEmptyComputePlugin<MapPostRequest, MapSpe
 
   @Override
   protected void writeResults(OutputStream out, Map<String, InputStream> dataStreams) throws IOException {
-
+    LOG.debug("Beginning writeResults for map plugin with output id: " + _pluginSpec.getOutputEntityId());
     // create scanner and line parser
     InputStreamReader isReader = new InputStreamReader(new BufferedInputStream(dataStreams.get(DEFAULT_SINGLE_STREAM_NAME)));
     BufferedReader reader = new BufferedReader(isReader);
@@ -139,10 +142,11 @@ public class MapPlugin extends AbstractEmptyComputePlugin<MapPostRequest, MapSpe
           aggregator.putIfAbsent(row[geoVarIndex], new GeoVarData());
           aggregator.get(row[geoVarIndex]).addRow(latitude, longitude);
         }
-        nextLine = reader.readLine();
-      }  
+      }
+      nextLine = reader.readLine();
     }
 
+    LOG.debug("Writing aggregated results for " + entityRecordsWithGeoVar + " records");
     // begin output object and single property containing array of map elements
     out.write("{\"mapElements\":[".getBytes(StandardCharsets.UTF_8));
     boolean first = true;


### PR DESCRIPTION
## Overview
* If the last row of the output had a null geo variable, we would never break from the loop due to `nextLine = reader.readLine();` being placed inside the null check statement instead of outside, where it belongs.

## Testing
Ran the map markers plugin on the megastudy in a dev environment with this fix:

```
{
    "mapElements": [
        {
            "minLon": 138.531,
            "entityCount": 48,
            "maxLat": -34.1753,
            "minLat": -35.6846,
            "geoAggregateValue": "r",
            "avgLat": -34.94760567732921,
            "maxLon": 140.777,
            "avgLon": 139.02227612840434
        },
        {
            "minLon": 0.06527,
            "entityCount": 185,
            "maxLat": 38.4833,
            "minLat": 0.053156,
            "geoAggregateValue": "s",
            "avgLat": 12.324681379623996,
            "maxLon": 42.3311,
            "avgLon": 26.790599999466025
        },
        {
            "minLon": -17.4536,
            "entityCount": 213,
            "maxLat": 17.5707,
            "minLat": 4.37854,
            "geoAggregateValue": "e",
            "avgLat": 10.555474728572726,
            "maxLon": -0.00861,
            "avgLon": -7.521723633844274
        },
        {
            "minLon": 9.43,
            "entityCount": 375,
            "maxLat": -0.1,
            "minLat": -27.23,
            "geoAggregateValue": "k",
            "avgLat": -12.193749098824387,
            "maxLon": 44.7455,
            "avgLon": 30.62056801442935
        },
        {
            "minLon": 45.2167,
            "entityCount": 47,
            "maxLat": -13.2,
            "minLat": -25.1783,
            "geoAggregateValue": "m",
            "avgLat": -19.910347429750672,
            "maxLon": 49.3986,
            "avgLon": 47.33528992293393
        }
    ],
    "config": {
        "completeCasesGeoVar": 868
    }
}
```