### PR TITLE
update dependencyOrder for apps

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/abundance/AbundanceBoxplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/abundance/AbundanceBoxplotPlugin.java
@@ -46,7 +46,7 @@ public class AbundanceBoxplotPlugin extends AbstractPlugin<AbundanceBoxplotPostR
   @Override
   public ConstraintSpec getConstraintSpec() {
     return new ConstraintSpec()
-      .dependencyOrder(List.of("overlayVariable", "facetVariable"))
+    .dependencyOrder(List.of("yAxisVariable"), List.of("xAxisVariable"), List.of("overlayVariable", "facetVariable"))
       .pattern()
         .element("overlayVariable")
           .required(false)

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/abundance/AbundanceScatterplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/abundance/AbundanceScatterplotPlugin.java
@@ -46,7 +46,7 @@ public class AbundanceScatterplotPlugin extends AbstractPlugin<AbundanceScatterp
   @Override
   public ConstraintSpec getConstraintSpec() {
     return new ConstraintSpec()
-      .dependencyOrder(List.of("xAxisVariable"), List.of("facetVariable"))
+    .dependencyOrder(List.of("yAxisVariable", "xAxisVariable"), List.of("overlayVariable", "facetVariable"))
       .pattern()
         .element("xAxisVariable")
           .types(APIVariableType.NUMBER, APIVariableType.DATE, APIVariableType.INTEGER)

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/alphadiv/AlphaDivBoxplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/alphadiv/AlphaDivBoxplotPlugin.java
@@ -45,7 +45,7 @@ public class AlphaDivBoxplotPlugin extends AbstractPlugin<AlphaDivBoxplotPostReq
   @Override
   public ConstraintSpec getConstraintSpec() {
     return new ConstraintSpec()
-      .dependencyOrder(List.of("xAxisVariable"), List.of("overlayVariable", "facetVariable"))
+    .dependencyOrder(List.of("yAxisVariable"), List.of("xAxisVariable"), List.of("overlayVariable", "facetVariable"))
       .pattern()
         .element("xAxisVariable")
           .maxValues(10)

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/alphadiv/AlphaDivScatterplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/alphadiv/AlphaDivScatterplotPlugin.java
@@ -45,7 +45,7 @@ public class AlphaDivScatterplotPlugin extends AbstractPlugin<AlphaDivScatterplo
   @Override
   public ConstraintSpec getConstraintSpec() {
     return new ConstraintSpec()
-      .dependencyOrder(List.of("xAxisVariable"), List.of("overlayVariable", "facetVariable"))
+    .dependencyOrder(List.of("yAxisVariable", "xAxisVariable"), List.of("overlayVariable", "facetVariable"))
       .pattern()
         .element("xAxisVariable")
           .types(APIVariableType.NUMBER, APIVariableType.DATE, APIVariableType.INTEGER)

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/betadiv/BetaDivScatterplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/betadiv/BetaDivScatterplotPlugin.java
@@ -44,7 +44,7 @@ public class BetaDivScatterplotPlugin extends AbstractPlugin<BetaDivScatterplotP
   @Override
   public ConstraintSpec getConstraintSpec() {
     return new ConstraintSpec()
-      .dependencyOrder(List.of("overlayVariable"))
+      .dependencyOrder(List.of("yAxisVariable", "xAxisVariable"), List.of("overlayVariable"))
       .pattern()
         .element("overlayVariable")
           .required(false)


### PR DESCRIPTION
Resolves #246 


For compute apps, include all plot variables in the dependency order. The fronten reads this dependency order, and can (see [PR](https://github.com/VEuPathDB/web-monorepo/pull/38)) use this dep order to correctly limit variables in the variable picker.

