### PR TITLE
Include count in the marker regardless of value spec

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -1792,13 +1792,18 @@ types:
     properties:
       overlayValues:
         type: string[]
+  RangeWithCountAndValue:
+    type: BinRangeWithValue
+    additionalProperties: false
+    properties:
+      count: number
   StandaloneMapElementInfo:
     type: object
     additionalProperties: false
     properties:
       geoAggregateValue: string
       entityCount: number
-      overlayValues: BinRangeWithValue[]
+      overlayValues: RangeWithCountAndValue[]
       avgLat: number
       avgLon: number
       minLat: number

--- a/schema/url/standalone-map/plugin-standalone-map-markers.raml
+++ b/schema/url/standalone-map/plugin-standalone-map-markers.raml
@@ -60,6 +60,13 @@ types:
       overlayValues:
         type: string[]
 
+  # Value (count or proportion) is specified by ValueSpec while count is always returned as count.
+  RangeWithCountAndValue:
+    additionalProperties: false
+    type: BinRangeWithValue
+    properties:
+      count: number
+
   StandaloneMapElementInfo:
     additionalProperties: false
     properties:
@@ -68,7 +75,7 @@ types:
       entityCount:
         type: number
       overlayValues:
-        type: BinRangeWithValue[]
+        type: RangeWithCountAndValue[]
       avgLat:
         type: number
       avgLon:

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/StandaloneMapMarkersPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/StandaloneMapMarkersPlugin.java
@@ -3,13 +3,11 @@ package org.veupathdb.service.eda.ds.plugin.standalonemap;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.gusdb.fgputil.DelimitedDataParser;
 import org.gusdb.fgputil.geo.GeographyUtil.GeographicPoint;
@@ -113,17 +111,20 @@ public class StandaloneMapMarkersPlugin extends AbstractEmptyComputePlugin<Stand
       }  
     }
 
-    List<BinRangeWithValue> getOverlayValues(String valueSpec) {
-      List<BinRangeWithValue> overlayValuesResponse = new ArrayList<>();
+    List<RangeWithCountAndValue> getOverlayValues(String valueSpec) {
+      List<RangeWithCountAndValue> overlayValuesResponse = new ArrayList<>();
 
       for (String overlayValue : overlayValuesCount.keySet()) {
-        BinRangeWithValue newValue = new BinRangeWithValueImpl();
+        RangeWithCountAndValue newValue = new RangeWithCountAndValueImpl();
         newValue.setBinLabel(overlayValue);
-        newValue.setValue(valueSpec.equals("count") ? overlayValuesCount.get(overlayValue).get() : overlayValuesProportion.get(overlayValue));
+        newValue.setCount(overlayValuesCount.get(overlayValue).get());
+        newValue.setValue(valueSpec.equals(ValueSpec.PROPORTION.getValue())
+            ? overlayValuesProportion.get(overlayValue)
+            : overlayValuesCount.get(overlayValue).get());
         overlayValuesResponse.add(newValue);
       }
 
-      return(overlayValuesResponse);
+      return overlayValuesResponse;
     }
   }
 


### PR DESCRIPTION
Resolves #261

This changes is a little awkward from the model perspective, but this is a backwards-compatible implementation that includes count when proportion is requested.

Tested against mega study, requested both value specs.