### PR TITLE
Fix validation for bubble markers plugin

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/BubbleMapMarkersPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/BubbleMapMarkersPlugin.java
@@ -80,6 +80,9 @@ public class BubbleMapMarkersPlugin extends AbstractEmptyComputePlugin<Standalon
           .orElse(null)));
     if (pluginSpec.getOverlayConfig() != null) {
       try {
+        if (pluginSpec.getOverlayConfig().getAggregationConfig() == null) {
+          throw new ValidationException("aggregationConfig is a required field.");
+        }
         _overlaySpecification = new QuantitativeAggregateConfiguration(pluginSpec.getOverlayConfig().getAggregationConfig(),
             getUtil().getVariableDataShape(pluginSpec.getOverlayConfig().getOverlayVariable()));
       } catch (IllegalArgumentException e) {

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/QuantitativeAggregateConfiguration.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/QuantitativeAggregateConfiguration.java
@@ -23,8 +23,7 @@ public class QuantitativeAggregateConfiguration {
   public QuantitativeAggregateConfiguration(QuantitativeAggregationConfig overlayConfig,
                                             String varShape) {
     if (CATEGORICAL.equals(overlayConfig.getOverlayType())) {
-      if (!varShape.equalsIgnoreCase(APIVariableDataShape.CATEGORICAL.getValue())
-          && !varShape.equalsIgnoreCase(APIVariableDataShape.ORDINAL.getValue())) {
+      if (varShape.equalsIgnoreCase(APIVariableDataShape.CONTINUOUS.getValue())) {
         throw new IllegalArgumentException("Incorrect overlay configuration type for categorical var: " + varShape);
       }
       CategoricalAggregationConfig categoricalConfig = (CategoricalAggregationConfig) overlayConfig;


### PR DESCRIPTION
Make sure categorical overlays work for all categorical variable types. Previously, binary variables were getting rejected by validation.

This resolves https://github.com/VEuPathDB/EdaDataService/issues/294