### PR TITLE
update diff abund comparator for continuous vars

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -651,8 +651,8 @@ types:
     type: object
     properties:
       variable: VariableSpec
-      groupA: string[]
-      groupB: string[]
+      groupA: LabeledRange[]
+      groupB: LabeledRange[]
   DifferentialAbundanceStatsResponse:
     type: object
     properties:


### PR DESCRIPTION
In the compute service we recently updated the api for differential abundance. The main update changed the groups from arrays of strings to arrays of `LabeledRange`. The data service needs to know about this change as well. So, this PR updates library.raml so that the ds now expects the correct format :) 