### PR TITLE
add empty correlation skeleton

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -527,6 +527,21 @@ securitySchemes:
               application/json:
                 type: lib.DifferentialAbundanceStatsResponse
 
+  /correlationassaymetadata/visualizations:
+    displayName: Visualizations for discovering corrleations between assay data and sample metadata
+
+    /bipartitenetwork:
+      post:
+        description: Returns data required to create a volcanoplot from a differential abundance analysis.
+        body:
+          application/json:
+            type: lib.CorrelationAssayMetadataBipartitenetworkPostRequest
+        responses:
+          200:
+            body:
+              application/json:
+                type: lib.CorrelationAssayMetadataStatsResponse
+
   /distributions/visualizations:
     displayName: Visualizations for exploring distributions of data.
 

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -70,6 +70,7 @@ types:
       displayRangeMax?: any
       vocabulary?: string[]
       imputeZero: boolean
+      hasStudyDependentVocabulary?: boolean
       isCollection: boolean
       members?: VariableSpec[]
   ComputedVariableMetadata:
@@ -372,7 +373,7 @@ types:
       isMergeKey: boolean
       isMultiValued: boolean
       imputeZero: boolean
-      hasStudySpecificVocabulary?: boolean
+      hasStudyDependentVocabulary?: boolean
       variableSpecToImputeZeroesFor?: VariableSpec
   API_VariableType:
     type: string

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -70,7 +70,6 @@ types:
       displayRangeMax?: any
       vocabulary?: string[]
       imputeZero: boolean
-      hasStudyDependentVocabulary?: boolean
       isCollection: boolean
       members?: VariableSpec[]
   ComputedVariableMetadata:
@@ -373,7 +372,7 @@ types:
       isMergeKey: boolean
       isMultiValued: boolean
       imputeZero: boolean
-      hasStudyDependentVocabulary?: boolean
+      hasStudySpecificVocabulary?: boolean
       variableSpecToImputeZeroesFor?: VariableSpec
   API_VariableType:
     type: string
@@ -777,6 +776,12 @@ types:
       overlayVariable:
         type: VariableSpec
         required: false
+  CorrelationAssayMetadataBipartitenetworkPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: EmptyDataPluginSpec
+      config: EmptyDataPluginSpec
+  CorrelationAssayMetadataStatsResponse: DifferentialAbundanceStatsResponse
   DifferentialAbundanceVolcanoplotPostRequest:
     type: DataPluginRequestBase
     properties:

--- a/schema/url/correlationassaymetadata/plugin-correlationassaymetadata-bipartitenetwork.raml
+++ b/schema/url/correlationassaymetadata/plugin-correlationassaymetadata-bipartitenetwork.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0 Library
+
+types:
+
+# Temporary until the backend is really ready
+  CorrelationAssayMetadataBipartitenetworkPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: EmptyDataPluginSpec
+      config: EmptyDataPluginSpec
+
+  CorrelationAssayMetadataStatsResponse:
+    type: DifferentialAbundanceStatsResponse

--- a/src/main/java/org/veupathdb/service/eda/ds/metadata/AppsMetadata.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/metadata/AppsMetadata.java
@@ -11,6 +11,7 @@ import org.veupathdb.service.eda.ds.plugin.alphadiv.AlphaDivBoxplotPlugin;
 import org.veupathdb.service.eda.ds.plugin.alphadiv.AlphaDivScatterplotPlugin;
 import org.veupathdb.service.eda.ds.plugin.abundance.AbundanceBoxplotPlugin;
 import org.veupathdb.service.eda.ds.plugin.abundance.AbundanceScatterplotPlugin;
+import org.veupathdb.service.eda.ds.plugin.correlationassaymetadata.CorrelationAssayMetadataBipartitenetworkPlugin;
 import org.veupathdb.service.eda.ds.plugin.pass.BarplotPlugin;
 import org.veupathdb.service.eda.ds.plugin.pass.BoxplotPlugin;
 import org.veupathdb.service.eda.ds.plugin.pass.ContTablePlugin;
@@ -113,6 +114,10 @@ public class AppsMetadata {
           "Find taxa or genes that are differentially abundant between two groups.",
           List.of(MICROBIOME_PROJECT),
           viz("volcanoplot", new DifferentialAbundanceVolcanoplotPlugin())),
+      app("correlationassaymetadata", "Correlation", "correlationassaymetadata",
+          "Discover taxa or genes correlated with metadata.",
+          List.of(MICROBIOME_PROJECT),
+          viz("bipartitenetwork", new CorrelationAssayMetadataBipartitenetworkPlugin())),
       app("distributions", "Distributions", null,
           "Plot simple distributions for any continuous variable, including metadata (e.g. age, height, etc.) or microbial assay results.",
           List.of(MICROBIOME_PROJECT),

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/correlationassaymetadata/CorrelationAssayMetadataBipartitenetworkPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/correlationassaymetadata/CorrelationAssayMetadataBipartitenetworkPlugin.java
@@ -57,6 +57,7 @@ public class CorrelationAssayMetadataBipartitenetworkPlugin extends AbstractPlug
 
   @Override
   protected void writeResults(OutputStream out, Map<String, InputStream> dataStreams) throws IOException {
-    writeComputeStatsResponseToOutput(out);
+    System.out.println("I'm writing results!");
+    // writeComputeStatsResponseToOutput(out);
   }
 }

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/correlationassaymetadata/CorrelationAssayMetadataBipartitenetworkPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/correlationassaymetadata/CorrelationAssayMetadataBipartitenetworkPlugin.java
@@ -1,0 +1,62 @@
+package org.veupathdb.service.eda.ds.plugin.correlationassaymetadata;
+
+import org.gusdb.fgputil.validation.ValidationException;
+import org.veupathdb.service.eda.common.client.spec.StreamSpec;
+import org.veupathdb.service.eda.ds.metadata.AppsMetadata;
+import org.veupathdb.service.eda.ds.core.AbstractPlugin;
+import org.veupathdb.service.eda.generated.model.BoxplotPostRequest;
+import org.veupathdb.service.eda.generated.model.BoxplotSpec;
+// import org.veupathdb.service.eda.generated.model.CorrelationAssayMetadataComputeConfig;
+import org.veupathdb.service.eda.generated.model.CorrelationAssayMetadataBipartitenetworkPostRequest;
+import org.veupathdb.service.eda.generated.model.EmptyDataPluginSpec;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class CorrelationAssayMetadataBipartitenetworkPlugin extends AbstractPlugin<CorrelationAssayMetadataBipartitenetworkPostRequest, EmptyDataPluginSpec, EmptyDataPluginSpec> {
+
+  @Override
+  public String getDisplayName() {
+    return "Bipartite network";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Visualize the correlation between two sets of data";
+  }
+
+  @Override
+  public List<String> getProjects() {
+    return List.of(AppsMetadata.MICROBIOME_PROJECT);
+  }
+
+  @Override
+  protected ClassGroup getTypeParameterClasses() {
+    return new ClassGroup(CorrelationAssayMetadataBipartitenetworkPostRequest.class, EmptyDataPluginSpec.class, EmptyDataPluginSpec.class);
+  }
+
+  @Override
+  protected boolean computeGeneratesVars() {
+    return false;
+  }
+
+  @Override
+  protected void validateVisualizationSpec(EmptyDataPluginSpec pluginSpec) throws ValidationException {
+    // nothing to do here
+  }
+
+  @Override
+  protected List<StreamSpec> getRequestedStreams(EmptyDataPluginSpec pluginSpec) {
+    // this plugin only uses the stats result of the compute; no tabular data streams needed
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected void writeResults(OutputStream out, Map<String, InputStream> dataStreams) throws IOException {
+    writeComputeStatsResponseToOutput(out);
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/ds/service/AppsService.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/service/AppsService.java
@@ -19,6 +19,7 @@ import org.veupathdb.service.eda.ds.Resources;
 import org.veupathdb.service.eda.ds.metadata.AppsMetadata;
 import org.veupathdb.service.eda.ds.core.AbstractPlugin;
 import org.veupathdb.service.eda.ds.plugin.differentialabundance.DifferentialAbundanceVolcanoplotPlugin;
+import org.veupathdb.service.eda.ds.plugin.correlationassaymetadata.CorrelationAssayMetadataBipartitenetworkPlugin;
 import org.veupathdb.service.eda.ds.plugin.betadiv.BetaDivScatterplotPlugin;
 import org.veupathdb.service.eda.ds.plugin.alphadiv.AlphaDivBoxplotPlugin;
 import org.veupathdb.service.eda.ds.plugin.alphadiv.AlphaDivScatterplotPlugin;
@@ -340,6 +341,13 @@ public class AppsService implements Apps {
   public PostAppsDifferentialabundanceVisualizationsVolcanoplotResponse postAppsDifferentialabundanceVisualizationsVolcanoplot(DifferentialAbundanceVolcanoplotPostRequest entity) {
     return wrapPlugin(() -> PostAppsDifferentialabundanceVisualizationsVolcanoplotResponse.respond200WithApplicationJson(
         new DifferentialAbundanceStatsResponseStream(processRequest(new DifferentialAbundanceVolcanoplotPlugin(), entity))));
+  }
+
+  @DisableJackson
+  @Override
+  public PostAppsCorrelationassaymetadataVisualizationsBipartitenetworkResponse postAppsCorrelationassaymetadataVisualizationsBipartitenetwork(CorrelationAssayMetadataBipartitenetworkPostRequest entity) {
+    return wrapPlugin(() -> PostAppsCorrelationassaymetadataVisualizationsBipartitenetworkResponse.respond200WithApplicationJson(
+        new CorrelationAssayMetadataStatsResponseStream(processRequest(new CorrelationAssayMetadataBipartitenetworkPlugin(), entity))));
   }
 
   @DisableJackson


### PR DESCRIPTION
Resolves task in https://github.com/VEuPathDB/web-monorepo/issues/512


Adds the skeleton of a correlation bipartite network viz so that the frontend can actually see a visualization. The goal is to really just let the frontend have the endpoint, but as a byproduct we've gone ahead and set up some of the plugin skeleton.