### PR TITLE
Fix quantitative bubble marker plugins

### DIFF
--- a/api-test/settings.gradle.kts
+++ b/api-test/settings.gradle.kts
@@ -1,0 +1,4 @@
+// adds repos for gradle plugin resolution and ensures github creds are provided to the build
+apply {
+  from("https://raw.githubusercontent.com/VEuPathDB/lib-gradle-container-utils/v4.8.9/includes/common.settings.gradle.kts")
+}

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/BubbleMapMarkersLegendPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/BubbleMapMarkersLegendPlugin.java
@@ -88,7 +88,7 @@ public class BubbleMapMarkersLegendPlugin extends AbstractEmptyComputePlugin<Sta
             pluginSpec.getColorLegendConfig().getQuantitativeOverlayConfig().getAggregationConfig(),
             getUtil().getVariableDataShape(overlayVar),
             getUtil().getVariableType(overlayVar),
-            getUtil().getVocabulary(pluginSpec.getColorLegendConfig().getQuantitativeOverlayConfig().getOverlayVariable()));
+            () -> getUtil().getVocabulary(pluginSpec.getColorLegendConfig().getQuantitativeOverlayConfig().getOverlayVariable()));
       } catch (IllegalArgumentException e) {
         throw new ValidationException(e.getMessage());
       }

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/BubbleMapMarkersPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/BubbleMapMarkersPlugin.java
@@ -82,12 +82,11 @@ public class BubbleMapMarkersPlugin extends AbstractEmptyComputePlugin<Standalon
         if (pluginSpec.getOverlayConfig().getAggregationConfig() == null) {
           throw new ValidationException("aggregationConfig is a required field.");
         }
-        List<String> overlayVocab = getUtil().getVocabulary(pluginSpec.getOverlayConfig().getOverlayVariable());
         _overlaySpecification = new QuantitativeAggregateConfiguration(
             pluginSpec.getOverlayConfig().getAggregationConfig(),
             getUtil().getVariableDataShape(pluginSpec.getOverlayConfig().getOverlayVariable()),
             getUtil().getVariableType(pluginSpec.getOverlayConfig().getOverlayVariable()),
-            overlayVocab);
+            () -> getUtil().getVocabulary(pluginSpec.getOverlayConfig().getOverlayVariable()));
       } catch (IllegalArgumentException e) {
         throw new ValidationException(e.getMessage());
       }

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/CollectionMapMarkersPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/CollectionMapMarkersPlugin.java
@@ -67,7 +67,7 @@ public class CollectionMapMarkersPlugin extends AbstractEmptyComputePlugin<Stand
         _aggregateConfig = new QuantitativeAggregateConfiguration(pluginSpec.getAggregatorConfig(),
             getUtil().getCollectionDataShape(pluginSpec.getCollection().getCollection()),
             getUtil().getCollectionType(pluginSpec.getCollection().getCollection()),
-            getUtil().getCollectionVocabulary(pluginSpec.getCollection().getCollection()));
+            () -> getUtil().getCollectionVocabulary(pluginSpec.getCollection().getCollection()));
       } catch (IllegalArgumentException e) {
         throw new ValidationException(e.getMessage());
       }

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/QuantitativeAggregateConfiguration.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/QuantitativeAggregateConfiguration.java
@@ -17,6 +17,7 @@ import java.time.ZoneOffset;
 import java.util.HashSet;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.veupathdb.service.eda.generated.model.OverlayType.CATEGORICAL;
 
@@ -33,7 +34,7 @@ public class QuantitativeAggregateConfiguration {
   public QuantitativeAggregateConfiguration(QuantitativeAggregationConfig overlayConfig,
                                             String varShape,
                                             String variableType,
-                                            List<String> overlayVocab) {
+                                            Supplier<List<String>> vocabSupplier) {
       this.variableType = variableType;
     if (CATEGORICAL.equals(overlayConfig.getOverlayType())) {
       if (varShape.equalsIgnoreCase(APIVariableDataShape.CONTINUOUS.getValue())) {
@@ -56,7 +57,7 @@ public class QuantitativeAggregateConfiguration {
          return new ProportionWithConfidenceAggregator(index,
               categoricalConfig.getNumeratorValues(),
               categoricalConfig.getDenominatorValues(),
-              overlayVocab);
+              vocabSupplier.get());
         }
       };
     } else {

--- a/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/MapMarkerRowProcessorTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/MapMarkerRowProcessorTest.java
@@ -36,11 +36,9 @@ public class MapMarkerRowProcessorTest {
         -2,
         2
     );
-    String inputData = new StringBuilder()
-        .append(generateTabularRow(0.1, 0.1, "a", "1.0", "1.0"))
-        .append(generateTabularRow(0.1, 0.1, "a", "90.0", "1.0"))
-        .append(generateTabularRow(0.1, 0.1, "a", "500.0", "1.0"))
-        .toString();
+    String inputData = generateTabularRow(0.1, 0.1, "a", "1.0", "1.0") +
+        generateTabularRow(0.1, 0.1, "a", "90.0", "1.0") +
+        generateTabularRow(0.1, 0.1, "a", "500.0", "1.0");
     InputStream inputStream = new ByteArrayInputStream(inputData.getBytes(StandardCharsets.UTF_8));
     Reader reader = new InputStreamReader(inputStream);
     BufferedReader bufferedReader = new BufferedReader(reader);
@@ -55,7 +53,7 @@ public class MapMarkerRowProcessorTest {
         headers::get,
         headerToIndex::get,
         List.of("E1.C1", "E1.C2"), // just collection vars.,
-        new QuantitativeAggregateConfiguration(aggregationConfig, "continuous", "number", List.of("1.0", "90.0", "500.0"))
+        new QuantitativeAggregateConfiguration(aggregationConfig, "continuous", "number", () -> List.of("1.0", "90.0", "500.0"))
     );
     Map<String, MarkerData<Map<String, AveragesWithConfidence>>> data = collectionAggregator.process(bufferedReader, parser, viewport, aggregator);
     Map<String, AveragesWithConfidence> aMarkerData = data.get("a").getMarkerAggregator().finish();
@@ -75,11 +73,9 @@ public class MapMarkerRowProcessorTest {
         -2,
         2
     );
-    String inputData = new StringBuilder()
-        .append(generateTabularRow(0.1, 0.1, "a", "a", "b"))
-        .append(generateTabularRow(0.1, 0.1, "a", "a", "b"))
-        .append(generateTabularRow(0.1, 0.1, "a", "b", "a"))
-        .toString();
+    String inputData = generateTabularRow(0.1, 0.1, "a", "a", "b") +
+        generateTabularRow(0.1, 0.1, "a", "a", "b") +
+        generateTabularRow(0.1, 0.1, "a", "b", "a");
     InputStream inputStream = new ByteArrayInputStream(inputData.getBytes(StandardCharsets.UTF_8));
     Reader reader = new InputStreamReader(inputStream);
     BufferedReader bufferedReader = new BufferedReader(reader);
@@ -96,7 +92,7 @@ public class MapMarkerRowProcessorTest {
         headers::get,
         headerToIndex::get,
         List.of("E1.C1", "E1.C2"), // just collection vars.,
-        new QuantitativeAggregateConfiguration(aggregationConfig, "categorical", "string", List.of("a", "b"))
+        new QuantitativeAggregateConfiguration(aggregationConfig, "categorical", "string", () -> List.of("a", "b"))
     );
     Map<String, MarkerData<Map<String, AveragesWithConfidence>>> data = collectionAggregator.process(bufferedReader, parser, viewport, aggregator);
     Map<String, AveragesWithConfidence> aMarkerData = data.get("a").getMarkerAggregator().finish();


### PR DESCRIPTION
## Overview
Lazily load vocabulary to ensure we only try to retrieve it for categorical variables.