### PR TITLE
bubbles marker endpoint: only add marker data to output when there is non-null overlayValue

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/BubbleMapMarkersPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/BubbleMapMarkersPlugin.java
@@ -152,10 +152,12 @@ public class BubbleMapMarkersPlugin extends AbstractEmptyComputePlugin<Standalon
       MarkerAggregator<Double> aggregator = data.getMarkerAggregator();
       if (aggregator != null) {
         Double aggregation = aggregator.finish();
-        if (aggregation != null)
+        if (aggregation != null) {
           mapEle.setOverlayValue(overlayConfig.map(oc -> oc.serializeAverage(aggregation)).orElse(null));
+	  // only output marker data where there are overlay values (issue #334)
+	  output.add(mapEle);
+	}
       }
-      output.add(mapEle);
     }
     StandaloneMapBubblesPostResponse response = new StandaloneMapBubblesPostResponseImpl();
     response.setMapElements(output);


### PR DESCRIPTION
Fixes #334 

Builds on https://github.com/VEuPathDB/EdaDataService/commit/d27dea372da9186851c0912e998a6885ffc4d507 