### PR TITLE
Optimize the bubble markers to count the negation of filter values set when smaller

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregator.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregator.java
@@ -1,6 +1,8 @@
 package org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator;
 
 import com.google.common.collect.Sets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Set;
 
@@ -9,6 +11,8 @@ import java.util.Set;
  * set of numerator values over number of elements with values in a set of denominator values.
  */
 public class CategoricalProportionAggregator implements MarkerAggregator<Double> {
+  private static final Logger LOG = LogManager.getLogger(CategoricalProportionAggregator.class);
+
   private final boolean negationMode;
   private final int index;
   private final Set<String> numeratorMatchSet;
@@ -18,25 +22,13 @@ public class CategoricalProportionAggregator implements MarkerAggregator<Double>
   private int distinctDenominatorMatchCount = 0;
   private int numNonNullMatches = 0;
 
-  public CategoricalProportionAggregator(Set<String> numeratorValues,
-                                         Set<String> denominatorValues,
-                                         Set<String> vocabulary,
+  public CategoricalProportionAggregator(Set<String> numeratorMatchSet,
+                                         Set<String> distinctDenominatorValues,
+                                         boolean negationMode,
                                          int index) {
-    if (!denominatorValues.containsAll(numeratorValues)) {
-      throw new IllegalArgumentException("Numerator values must be a subset of denominator values.");
-    }
-    Set<String> numeratorValuesNegation = Sets.difference(vocabulary, numeratorValues);
-    // Count one of the following depending on which is cheaper:
-    // 1. Total numerator matches.
-    // 2. Everything that doesn't match the numerator.
-    if (numeratorValuesNegation.size() < numeratorValues.size()) {
-      negationMode = true;
-      this.numeratorMatchSet = numeratorValuesNegation;
-    } else {
-      negationMode = false;
-      this.numeratorMatchSet = numeratorValues;
-    }
-    this.distinctDenominatorValues = Sets.difference(denominatorValues, numeratorValues);
+   this.numeratorMatchSet = numeratorMatchSet;
+   this.distinctDenominatorValues = distinctDenominatorValues;
+   this.negationMode = negationMode;
     this.index = index;
   }
 

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregator.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregator.java
@@ -3,8 +3,13 @@ package org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator;
 import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.veupathdb.service.eda.generated.model.CategoricalAggregationConfig;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Map marker aggregator taking categorical variable and providing a ratio of number of elements with values in a
@@ -22,13 +27,13 @@ public class CategoricalProportionAggregator implements MarkerAggregator<Double>
   private int distinctDenominatorMatchCount = 0;
   private int numNonNullMatches = 0;
 
-  public CategoricalProportionAggregator(Set<String> numeratorMatchSet,
-                                         Set<String> distinctDenominatorValues,
-                                         boolean negationMode,
-                                         int index) {
-   this.numeratorMatchSet = numeratorMatchSet;
-   this.distinctDenominatorValues = distinctDenominatorValues;
-   this.negationMode = negationMode;
+  private CategoricalProportionAggregator(Set<String> numeratorMatchSet,
+                                          Set<String> distinctDenominatorValues,
+                                          boolean negationMode,
+                                          int index) {
+    this.numeratorMatchSet = numeratorMatchSet;
+    this.distinctDenominatorValues = distinctDenominatorValues;
+    this.negationMode = negationMode;
     this.index = index;
   }
 
@@ -54,15 +59,80 @@ public class CategoricalProportionAggregator implements MarkerAggregator<Double>
   @Override
   public Double finish() {
     int totalNumeratorMatches;
+
+    // Negation mode means we're counting every row that does NOT match the numerator for efficiency.
     if (negationMode) {
       totalNumeratorMatches = numNonNullMatches - numNumeratorMatches;
     } else {
       totalNumeratorMatches = numNumeratorMatches;
     }
+
+    // Since numerator is a subset of denominator, total denominator matches is numerator + distinct denominator matches.
     final int totalDenominatorMatches = totalNumeratorMatches + distinctDenominatorMatchCount;
     if (totalDenominatorMatches == 0) {
       return null;
     }
     return (double) totalNumeratorMatches / totalDenominatorMatches;
+  }
+
+  public static class CategoricalProportionAggregatorFactory implements ContinuousAggregators.ContinuousAggregatorFactory {
+    private final CategoricalAggregationConfig categoricalConfig;
+    private final List<String> vocab;
+    private final Set<String> distinctDenominatorValues;
+    private final Set<String> numeratorMatchSet;
+    private final boolean negationMode;
+
+    /**
+     * Constructs a CategoricalProportionAggregatorFactory. This factory abstracts the constructor of the
+     * CategoricalProportionAggregator class to avoid re-computing negation match set and distinct denominator values
+     * for each instance of CategoricalProportionAggregator for a given request.
+     *
+     * @param categoricalConfig The user-specified aggregation config for the request.
+     * @param vocabSupplier A supplier for the vocabulary of the variable of interest.
+     */
+    public CategoricalProportionAggregatorFactory(CategoricalAggregationConfig categoricalConfig,
+                                                  Supplier<List<String>> vocabSupplier) {
+      if (!categoricalConfig.getDenominatorValues().containsAll(categoricalConfig.getNumeratorValues())) {
+        throw new IllegalArgumentException("Numerator values match set must be a subset of denominator values match set.");
+      }
+
+      Set<String> numeratorMatchSet = new HashSet<>(categoricalConfig.getNumeratorValues());
+      Set<String> vocabulary = new HashSet<>(vocabSupplier.get());
+      Set<String> numeratorNegationMatchSet = Sets.difference(vocabulary, numeratorMatchSet);
+
+      // Count one of the following depending on which is cheaper:
+      // 1. Total numerator matches.
+      // 2. Everything that doesn't match the numerator.
+      if (numeratorNegationMatchSet.size() < numeratorMatchSet.size()) {
+        this.negationMode = true;
+        this.numeratorMatchSet = numeratorNegationMatchSet;
+      } else {
+        this.negationMode = false;
+        this.numeratorMatchSet = numeratorMatchSet;
+      }
+
+      // Since numerator values are a subset of denominator values, we know anything in the numerator set is always
+      // in the denominator. We can just check the distinct denominator values and add back in the numerator matches.
+      Set<String> denominatorValues = new HashSet<>(categoricalConfig.getDenominatorValues());
+      this.distinctDenominatorValues = Sets.difference(denominatorValues, numeratorMatchSet);
+      this.categoricalConfig = categoricalConfig;
+      this.vocab = vocabSupplier.get();
+    }
+
+    @Override
+    public MarkerAggregator<Double> create(int index, Function<String, Double> valueQuantifier) {
+      return new CategoricalProportionAggregator(numeratorMatchSet,
+          distinctDenominatorValues,
+          negationMode,
+          index);
+    }
+
+    @Override
+    public MarkerAggregator<AveragesWithConfidence> createWithConfidence(int index, Function<String, Double> valueQuantifier) {
+      return new ProportionWithConfidenceAggregator(index,
+          categoricalConfig.getNumeratorValues(),
+          categoricalConfig.getDenominatorValues(),
+          vocab);
+    }
   }
 }

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregator.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregator.java
@@ -11,7 +11,7 @@ import java.util.Set;
 public class CategoricalProportionAggregator implements MarkerAggregator<Double> {
   private final boolean negationMode;
   private final int index;
-  private final Set<String> numeratorValues;
+  private final Set<String> numeratorMatchSet;
   private final Set<String> distinctDenominatorValues;
 
   private int numNumeratorMatches = 0;
@@ -31,10 +31,10 @@ public class CategoricalProportionAggregator implements MarkerAggregator<Double>
     // 2. Everything that doesn't match the numerator.
     if (numeratorValuesNegation.size() < numeratorValues.size()) {
       negationMode = true;
-      this.numeratorValues = numeratorValuesNegation;
+      this.numeratorMatchSet = numeratorValuesNegation;
     } else {
       negationMode = false;
-      this.numeratorValues = numeratorValues;
+      this.numeratorMatchSet = numeratorValues;
     }
     this.distinctDenominatorValues = Sets.difference(denominatorValues, numeratorValues);
     this.index = index;
@@ -45,7 +45,7 @@ public class CategoricalProportionAggregator implements MarkerAggregator<Double>
     if (s == null) {
       return;
     }
-    if (numeratorValues.contains(s[index])) {
+    if (numeratorMatchSet.contains(s[index])) {
       numNumeratorMatches++;
     }
     if (distinctDenominatorValues.contains(s[index])) {
@@ -67,8 +67,8 @@ public class CategoricalProportionAggregator implements MarkerAggregator<Double>
     } else {
       totalNumeratorMatches = numNumeratorMatches;
     }
-    final int totalDenominatorMatches = numNumeratorMatches + distinctDenominatorMatchCount;
-    if (distinctDenominatorMatchCount == 0) {
+    final int totalDenominatorMatches = totalNumeratorMatches + distinctDenominatorMatchCount;
+    if (totalDenominatorMatches == 0) {
       return null;
     }
     return (double) totalNumeratorMatches / totalDenominatorMatches;

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/QuantitativeAggregateConfiguration.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/QuantitativeAggregateConfiguration.java
@@ -49,7 +49,9 @@ public class QuantitativeAggregateConfiguration {
         @Override
         public MarkerAggregator<Double> create(int index, Function<String, Double> valueQuantifier) {
           return new CategoricalProportionAggregator(new HashSet<>(categoricalConfig.getNumeratorValues()),
-              new HashSet<>(categoricalConfig.getDenominatorValues()), index);
+              new HashSet<>(categoricalConfig.getDenominatorValues()), 
+              new HashSet<>(vocabSupplier.get()),
+              index);
         }
 
         @Override

--- a/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/QuantitativeAggregateConfiguration.java
+++ b/src/main/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/QuantitativeAggregateConfiguration.java
@@ -1,11 +1,9 @@
 package org.veupathdb.service.eda.ds.plugin.standalonemap.markers;
 
-import com.google.common.collect.Sets;
 import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.AveragesWithConfidence;
 import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.CategoricalProportionAggregator;
 import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.ContinuousAggregators;
 import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.MarkerAggregator;
-import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.ProportionWithConfidenceAggregator;
 import org.veupathdb.service.eda.generated.model.APIVariableDataShape;
 import org.veupathdb.service.eda.generated.model.APIVariableType;
 import org.veupathdb.service.eda.generated.model.CategoricalAggregationConfig;
@@ -15,9 +13,7 @@ import org.veupathdb.service.eda.generated.model.QuantitativeAggregationConfig;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -47,7 +43,7 @@ public class QuantitativeAggregateConfiguration {
         throw new IllegalArgumentException("CategoricalQuantitativeOverlay numerator values must be a subset of denominator values.");
       }
       variableValueQuantifier = Double::valueOf;
-      aggregatorSupplier = new CategoricalProportionAggregatorFactory(categoricalConfig, vocabSupplier);
+      aggregatorSupplier = new CategoricalProportionAggregator.CategoricalProportionAggregatorFactory(categoricalConfig, vocabSupplier);
     } else {
       if (!varShape.equalsIgnoreCase(APIVariableDataShape.CONTINUOUS.getValue())) {
         throw new IllegalArgumentException("Incorrect overlay configuration type for continuous var: " + varShape);
@@ -78,48 +74,4 @@ public class QuantitativeAggregateConfiguration {
     }
   }
 
-  public static class CategoricalProportionAggregatorFactory implements ContinuousAggregators.ContinuousAggregatorFactory {
-    private final CategoricalAggregationConfig categoricalConfig;
-    private final Supplier<List<String>> vocabSupplier;
-    private final Set<String> distinctDenominatorValues;
-    private final Set<String> numeratorMatchSet;
-    boolean negationMode;
-
-    public CategoricalProportionAggregatorFactory(CategoricalAggregationConfig categoricalConfig,
-                                                  Supplier<List<String>> vocabSupplier) {
-      Set<String> numeratorValues = new HashSet<>(categoricalConfig.getNumeratorValues());
-      Set<String> vocabulary = new HashSet<>(vocabSupplier.get());
-      Set<String> numeratorValuesNegation = Sets.difference(vocabulary, numeratorValues);
-      // Count one of the following depending on which is cheaper:
-      // 1. Total numerator matches.
-      // 2. Everything that doesn't match the numerator.
-      if (numeratorValuesNegation.size() < numeratorValues.size()) {
-        this.negationMode = true;
-        this.numeratorMatchSet = numeratorValuesNegation;
-      } else {
-        this.negationMode = false;
-        this.numeratorMatchSet = numeratorValues;
-      }
-      Set<String> denominatorValues = new HashSet<>(categoricalConfig.getDenominatorValues());
-      this.distinctDenominatorValues = Sets.difference(denominatorValues, numeratorValues);
-      this.categoricalConfig = categoricalConfig;
-      this.vocabSupplier = vocabSupplier;
-    }
-
-    @Override
-    public MarkerAggregator<Double> create(int index, Function<String, Double> valueQuantifier) {
-      return new CategoricalProportionAggregator(numeratorMatchSet,
-          distinctDenominatorValues,
-          negationMode,
-          index);
-    }
-
-    @Override
-    public MarkerAggregator<AveragesWithConfidence> createWithConfidence(int index, Function<String, Double> valueQuantifier) {
-     return new ProportionWithConfidenceAggregator(index,
-          categoricalConfig.getNumeratorValues(),
-          categoricalConfig.getDenominatorValues(),
-          vocabSupplier.get());
-    }
-  }
 }

--- a/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregatorTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregatorTest.java
@@ -3,6 +3,9 @@ package org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.veupathdb.service.eda.ds.plugin.standalonemap.markers.QuantitativeAggregateConfiguration;
+import org.veupathdb.service.eda.generated.model.CategoricalAggregationConfig;
+import org.veupathdb.service.eda.generated.model.CategoricalAggregationConfigImpl;
 
 import java.util.Set;
 
@@ -11,7 +14,7 @@ public class CategoricalProportionAggregatorTest {
   @Test
   @DisplayName("Numerator small proportion of vocab.")
   public void test1() {
-    final MarkerAggregator<Double> agg = new CategoricalProportionAggregator(Set.of("1"),
+    final MarkerAggregator<Double> agg = createClassUnderTest(Set.of("1"),
         Set.of("1", "2", "3"),
         Set.of("1", "2", "3", "4", "5", "6"),
         0);
@@ -27,7 +30,7 @@ public class CategoricalProportionAggregatorTest {
   @Test
   @DisplayName("Numerator small proportion of vocab. Denominator all of vocab.")
   public void test2() {
-    final MarkerAggregator<Double> agg = new CategoricalProportionAggregator(Set.of("1"),
+    final MarkerAggregator<Double> agg = createClassUnderTest(Set.of("1"),
         Set.of("1", "2", "3", "4", "5", "6"),
         Set.of("1", "2", "3", "4", "5", "6"),
         0);
@@ -43,7 +46,7 @@ public class CategoricalProportionAggregatorTest {
   @Test
   @DisplayName("Numerator all of vocab. Denominator all of vocab.")
   public void test3() {
-    final MarkerAggregator<Double> agg = new CategoricalProportionAggregator(Set.of("1", "2", "3", "4", "5", "6"),
+    final MarkerAggregator<Double> agg = createClassUnderTest(Set.of("1", "2", "3", "4", "5", "6"),
         Set.of("1", "2", "3", "4", "5", "6"),
         Set.of("1", "2", "3", "4", "5", "6"),
         0);
@@ -59,7 +62,7 @@ public class CategoricalProportionAggregatorTest {
   @Test
   @DisplayName("Numerator most of vocab. Denominator all of vocab.")
   public void test4() {
-    final MarkerAggregator<Double> agg = new CategoricalProportionAggregator(Set.of("1", "3", "4", "5", "6"),
+    final MarkerAggregator<Double> agg = createClassUnderTest(Set.of("1", "3", "4", "5", "6"),
         Set.of("1", "2", "3", "4", "5", "6"),
         Set.of("1", "2", "3", "4", "5", "6"),
         0);
@@ -70,5 +73,13 @@ public class CategoricalProportionAggregatorTest {
     agg.addValue(new String[] { "2" });
     agg.addValue(new String[] { "1" });
     Assertions.assertEquals(5.0 / 6.0,  agg.finish(), 0.001);
+  }
+
+  private MarkerAggregator<Double> createClassUnderTest(Set<String> numeratorValues, Set<String> denominatorValues, Set<String> vocabValues, int index) {
+    CategoricalAggregationConfig c = new CategoricalAggregationConfigImpl();
+    c.setNumeratorValues(numeratorValues.stream().toList());
+    c.setDenominatorValues(denominatorValues.stream().toList());
+    return new QuantitativeAggregateConfiguration.CategoricalProportionAggregatorFactory(c, () -> vocabValues.stream().toList())
+        .create(index, Double::valueOf);
   }
 }

--- a/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregatorTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregatorTest.java
@@ -1,0 +1,74 @@
+package org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+public class CategoricalProportionAggregatorTest {
+
+  @Test
+  @DisplayName("Numerator small proportion of vocab.")
+  public void test1() {
+    final MarkerAggregator<Double> agg = new CategoricalProportionAggregator(Set.of("1"),
+        Set.of("1", "2", "3"),
+        Set.of("1", "2", "3", "4", "5", "6"),
+        0);
+    agg.addValue(new String[] { "6" });
+    agg.addValue(new String[] { "5" });
+    agg.addValue(new String[] { "4" });
+    agg.addValue(new String[] { "3" });
+    agg.addValue(new String[] { "2" });
+    agg.addValue(new String[] { "1" });
+    Assertions.assertEquals(0.333, agg.finish(), 0.001);
+  }
+
+  @Test
+  @DisplayName("Numerator small proportion of vocab. Denominator all of vocab.")
+  public void test2() {
+    final MarkerAggregator<Double> agg = new CategoricalProportionAggregator(Set.of("1"),
+        Set.of("1", "2", "3", "4", "5", "6"),
+        Set.of("1", "2", "3", "4", "5", "6"),
+        0);
+    agg.addValue(new String[] { "6" });
+    agg.addValue(new String[] { "5" });
+    agg.addValue(new String[] { "4" });
+    agg.addValue(new String[] { "3" });
+    agg.addValue(new String[] { "2" });
+    agg.addValue(new String[] { "1" });
+    Assertions.assertEquals(1.0 / 6.0, agg.finish(), 0.001);
+  }
+
+  @Test
+  @DisplayName("Numerator all of vocab. Denominator all of vocab.")
+  public void test3() {
+    final MarkerAggregator<Double> agg = new CategoricalProportionAggregator(Set.of("1", "2", "3", "4", "5", "6"),
+        Set.of("1", "2", "3", "4", "5", "6"),
+        Set.of("1", "2", "3", "4", "5", "6"),
+        0);
+    agg.addValue(new String[] { "6" });
+    agg.addValue(new String[] { "5" });
+    agg.addValue(new String[] { "4" });
+    agg.addValue(new String[] { "3" });
+    agg.addValue(new String[] { "2" });
+    agg.addValue(new String[] { "1" });
+    Assertions.assertEquals(1.0,  agg.finish(), 0.001);
+  }
+
+  @Test
+  @DisplayName("Numerator most of vocab. Denominator all of vocab.")
+  public void test4() {
+    final MarkerAggregator<Double> agg = new CategoricalProportionAggregator(Set.of("1", "3", "4", "5", "6"),
+        Set.of("1", "2", "3", "4", "5", "6"),
+        Set.of("1", "2", "3", "4", "5", "6"),
+        0);
+    agg.addValue(new String[] { "6" });
+    agg.addValue(new String[] { "5" });
+    agg.addValue(new String[] { "4" });
+    agg.addValue(new String[] { "3" });
+    agg.addValue(new String[] { "2" });
+    agg.addValue(new String[] { "1" });
+    Assertions.assertEquals(5.0 / 6.0,  agg.finish(), 0.001);
+  }
+}

--- a/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregatorTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/aggregator/CategoricalProportionAggregatorTest.java
@@ -3,7 +3,6 @@ package org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.veupathdb.service.eda.ds.plugin.standalonemap.markers.QuantitativeAggregateConfiguration;
 import org.veupathdb.service.eda.generated.model.CategoricalAggregationConfig;
 import org.veupathdb.service.eda.generated.model.CategoricalAggregationConfigImpl;
 
@@ -79,7 +78,7 @@ public class CategoricalProportionAggregatorTest {
     CategoricalAggregationConfig c = new CategoricalAggregationConfigImpl();
     c.setNumeratorValues(numeratorValues.stream().toList());
     c.setDenominatorValues(denominatorValues.stream().toList());
-    return new QuantitativeAggregateConfiguration.CategoricalProportionAggregatorFactory(c, () -> vocabValues.stream().toList())
+    return new CategoricalProportionAggregator.CategoricalProportionAggregatorFactory(c, () -> vocabValues.stream().toList())
         .create(index, Double::valueOf);
   }
 }

--- a/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/ContinuousAggregatorsTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/ContinuousAggregatorsTest.java
@@ -3,8 +3,12 @@ package org.veupathdb.service.eda.ds.plugin.standalonemap.markers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.AveragesWithConfidence;
+import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.CategoricalProportionAggregator;
 import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.ContinuousAggregators;
 import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.MarkerAggregator;
+
+import java.util.Set;
 
 public class ContinuousAggregatorsTest {
 
@@ -71,5 +75,4 @@ public class ContinuousAggregatorsTest {
     agg.addValue(new String[] { "1" });
     Assertions.assertEquals(3.5, agg.finish());
   }
-
 }

--- a/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/ContinuousAggregatorsTest.java
+++ b/src/test/java/org/veupathdb/service/eda/ds/plugin/standalonemap/markers/ContinuousAggregatorsTest.java
@@ -3,12 +3,8 @@ package org.veupathdb.service.eda.ds.plugin.standalonemap.markers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.AveragesWithConfidence;
-import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.CategoricalProportionAggregator;
 import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.ContinuousAggregators;
 import org.veupathdb.service.eda.ds.plugin.standalonemap.aggregator.MarkerAggregator;
-
-import java.util.Set;
 
 public class ContinuousAggregatorsTest {
 


### PR DESCRIPTION
## Overview
* Optimize the bubble markers to count the negation of the set of filter values if the set contains the majority of values in the vocabulary.
* This is especially useful when using the default configuration of the bubble markers where all values are selected.